### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A 3D filter control that gives users a fun way to browse between many segments.
 If you don't have cocoapods, visit http://www.cocoapods.org or follow the steps below:
 
 ~~~
-	# Install Commoand Line Tools in XCode->Preferences->Downloads first.
+	# Install Commoand Line Tools in Xcode->Preferences->Downloads first.
 	sudo gem install cocoapods
 	pod setup # Do not sudo here
 ~~~


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
